### PR TITLE
[ISSUE #51] Calculator divide() returns Infinity instead of raising on zero divisor

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -3,7 +3,7 @@
 def divide(a, b):
     """Divide a by b."""
     if b == 0:
-        raise ValueError("Cannot divide by zero")
+        raise ZeroDivisionError("division by zero")
     return a / b
 
 def calculate_average(numbers):

--- a/tests.py
+++ b/tests.py
@@ -17,7 +17,7 @@ def test_divide():
 
 def test_divide_by_zero():
     import pytest
-    with pytest.raises(ValueError):
+    with pytest.raises(ZeroDivisionError, match="division by zero"):
         divide(10, 0)
 
 def test_average_empty():


### PR DESCRIPTION
Fixes #51

## AI Fix — Issue #51

**Issue:** Calculator divide() returns Infinity instead of raising on zero divisor

**Description:**
## Problem

calculator.divide(10, 0) currently returns `math.inf` instead of raising a `ZeroDivisionError`. That leaks through tests.py::test_divide_by_zero and corrupts downstream stats routines that assume a number or an exception.

## Expected

Calling `divide(a, 0)` should raise `ZeroDivisionError("division by zero")`.

## Actual

Returns Python's float Infinity — tests do not flag it because the assertion checks truthiness rather than the exception type.

## Repro

```python
import calculator
calculator.divide(1, 0)   # -> inf, should raise
```

## Logs

N/A — no runtime error.

## Environment

- Python 3.11
- calculator.py @ main





**Changes Made:**
- calculator.py
- tests.py

status=ok | duration=32s | ## Changes Made
Modified `calculator.py` to make `divide(a, 0)` raise `ZeroDivisionError("division by zero")`, matching the expected Python behavior and the issue requirement.

Updated `tests.py` so `test_divide_by_zero` now asserts the correct exception type and message with `pytest.raises(ZeroDivisionError, match="division by zero")`, preventing regressions around the zero-divisor contract.

## Verification
Ran `pytest tests.py`.

Result: all tests passed, `19 passed in 0.01s`.

---
*Generated by SupportAgent (Codex)*